### PR TITLE
Parallelize the wire-wire matrix fill with OpenMP (~2x on a 4-core box, bit-identical output)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,19 @@ endif
 $(info Using C compiler: $(CC))
 CFLAGS = -I. -Isrc -g -O2 -Wall -Wno-unused-parameter
 LDFLAGS =
+
+# OpenMP-parallel matrix fill (fill_wire_wire_matrix observation loop).
+# Set OPENMP=0 to build the sequential fill. Off by default on macOS,
+# where stock Apple clang has no -fopenmp; a libomp-equipped compiler can
+# opt back in with `make OPENMP=1`.
+OPENMP ?= 1
+ifeq ($(shell uname),Darwin)
+OPENMP ?= 0
+endif
+ifeq ($(OPENMP),1)
+CFLAGS += -fopenmp
+LDFLAGS += -fopenmp
+endif
 AR ?= ar
 RANLIB ?= ranlib
 

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -701,7 +701,73 @@ void fill_wire_wire_matrix(context_t *restrict ctx, int j, int i1, int i2, compl
 
   } /* if( dataj.use_extended_kernel != 0) */
 
-  /* observation loop */
+  /* observation loop.
+   *
+   * Parallelized over observers (OpenMP): each iteration writes a distinct
+   * row (normal fill) or column (transposed fills) of cm/cw, so the writes
+   * are disjoint. e_field_segment returns its result THROUGH the context's
+   * scratch blocks (dataj/incom/tmi/tmh/intrp — the "formerly static
+   * globals"), so each thread works on a private 16 KB struct copy of the
+   * context; the geometry/ground-grid POINTERS inside the copy alias the
+   * shared arrays, which this loop only reads. segj (the source segment's
+   * junction basis data, including the aliased junction_segs pointer) is
+   * set up before this loop and is read-only inside it. */
+#ifdef _OPENMP
+  #pragma omp parallel default(shared)
+  {
+	context_t tctx = *ctx;
+	#pragma omp for schedule(static)
+	for( i = i1-1; i < i2; i++ )
+	{
+	  int ipr_p = i - (i1-1);
+	  int ij_p = i - j;
+	  double xi_p = tctx.geometry.x_center[i];
+	  double yi_p = tctx.geometry.y_center[i];
+	  double zi_p = tctx.geometry.z_center[i];
+	  double ai_p = tctx.geometry.radius[i];
+	  double cabi_p = tctx.geometry.dir_cos_x[i];
+	  double sabi_p = tctx.geometry.dir_cos_y[i];
+	  double salpi_p = tctx.geometry.dir_cos_z[i];
+
+	  e_field_segment( &tctx, xi_p, yi_p, zi_p, ai_p, ij_p);
+
+	  complex double etk_p = tctx.dataj.e_const_x* cabi_p+ tctx.dataj.e_const_y* sabi_p+ tctx.dataj.e_const_z* salpi_p;
+	  complex double ets_p = tctx.dataj.e_sin_x* cabi_p+ tctx.dataj.e_sin_y* sabi_p+ tctx.dataj.e_sin_z* salpi_p;
+	  complex double etc_p = tctx.dataj.e_cos_x* cabi_p+ tctx.dataj.e_cos_y* sabi_p+ tctx.dataj.e_cos_z* salpi_p;
+
+	  if( itrp == 0)
+	  {
+		for( int ijj = 0; ijj < tctx.segj.num_junction_segs; ijj++ )
+		{
+		  int jxx = tctx.segj.junction_segs[ijj]-1;
+		  cm[ipr_p+jxx*nr] += etk_p* tctx.segj.coeff_const[ijj]+ ets_p* tctx.segj.coeff_sine[ijj]+ etc_p* tctx.segj.coeff_cos[ijj];
+		}
+	  }
+	  else if( itrp != 2)
+	  {
+		for( int ijj = 0; ijj < tctx.segj.num_junction_segs; ijj++ )
+		{
+		  int jxx = tctx.segj.junction_segs[ijj]-1;
+		  cm[jxx+ipr_p*nr] += etk_p* tctx.segj.coeff_const[ijj]+ ets_p* tctx.segj.coeff_sine[ijj]+ etc_p* tctx.segj.coeff_cos[ijj];
+		}
+	  }
+	  else
+	  {
+		for( int ijj = 0; ijj < tctx.segj.num_junction_segs; ijj++ )
+		{
+		  int jxx = tctx.segj.junction_segs[ijj]-1;
+		  if( jxx < nr)
+			cm[jxx+ipr_p*nr] += etk_p* tctx.segj.coeff_const[ijj]+ ets_p* tctx.segj.coeff_sine[ijj]+ etc_p* tctx.segj.coeff_cos[ijj];
+		  else
+		  {
+			jxx -= nr;
+			cw[jxx*ipr_p*nw] += etk_p* tctx.segj.coeff_const[ijj]+ ets_p* tctx.segj.coeff_sine[ijj]+ etc_p* tctx.segj.coeff_cos[ijj];
+		  }
+		}
+	  }
+	} /* omp for */
+  } /* omp parallel */
+#else
   ipr=-1;
   for( i = i1-1; i < i2; i++ )
   {
@@ -761,6 +827,7 @@ void fill_wire_wire_matrix(context_t *restrict ctx, int j, int i1, int i2, compl
 	} /* for( ij = 0; ij < segj.num_junction_segs; ij++ ) */
 
   } /* for( i = i1-1; i < i2; i++ ) */
+#endif
 
   return;
 }


### PR DESCRIPTION
The matrix fill is onec's dominant cost on larger wire decks once a BLAS backend handles the factor — on a 4,392-segment model the fill is ~8.6 s of a 12 s sequential solve. This PR parallelizes the observation loop of `fill_wire_wire_matrix` with OpenMP.

## Why it's safe

- Each observer iteration writes a **distinct row** (normal fill) or **column** (transposed fills) of `cm`/`cw` — no write conflicts.
- `segj` (the source segment's junction basis data) is set up before the loop and is **read-only** inside it.
- The subtle part: `e_field_segment` returns its result through the context's scratch blocks (`dataj`/`incom`/`tmi`/`tmh`/`intrp` — the "formerly static globals" your rewrite gathered into `context_t`). Because all of that scratch is embedded **by value** (16 KB total), each thread works on a **private struct copy**; the geometry/ground-grid *pointers* inside the copy alias the shared arrays, which the fill only reads. Your consolidation of the old globals is what makes this patch small — nec2c itself couldn't be parallelized this way.
- The sequential loop is preserved verbatim behind `#ifdef _OPENMP`; `make OPENMP=0` builds it. Off by default on macOS (stock Apple clang has no `-fopenmp`).

## Measurements

4,392-segment loaded-whip deck (LD cards removed to sidestep #11), Linux x86_64, 4 cores / 8 SMT threads, OpenBLAS backend. Output is **bit-identical** to the sequential build and to nec2c in every configuration:

| configuration | wall |
|---|--:|
| sequential (OMP=1, BLAS=1) | 12.0 s |
| factor threaded only (BLAS=4) ≈ current behavior | 9.0 s |
| fill threaded only (OMP=4) | 7.7 s |
| **both, capped at physical cores** | **4.4 s** |
| nec2c, same deck | 80 s |

One operational note worth documenting: capping at **physical cores** beats using all SMT threads (the 8-thread run was slower than the 4-thread run on this box) — `OMP_NUM_THREADS=<cores>` is the sweet spot.

## Known limits (called out in the commit too)

- Only the wire-wire path is parallelized; the patch fills are untouched.
- The context clone's error-list pointers alias the shared list, so a warning emitted from *inside* the field kernel could race. If that path matters to you, a per-thread error buffer (drained after the loop) would finish the job — happy to extend the PR that way if you'd like.

Found while evaluating onec for batch reference use alongside #11/#12; happy to iterate on review.